### PR TITLE
Optimize dunes coalescing for splitting functionality

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -701,7 +701,7 @@ const Index = () => {
                   <form onSubmit={handleSendDune}>
                     <p>
                       <input
-                        type="string"
+                        type="text"
                         name="toAddress"
                         placeholder="Destination Address"
                         onChange={(e) => e.target.value}
@@ -709,15 +709,16 @@ const Index = () => {
                     </p>
                     <p>
                       <input
-                        type="string"
+                        type="number"
                         name="amount"
                         placeholder="Exact amount of the dune to send"
                         onChange={(e) => e.target.value}
+                        step="any"
                       />
                     </p>
                     <p>
                       <input
-                        type="string"
+                        type="text"
                         name="dune"
                         placeholder="name of dune being transferred"
                         onChange={(e) => e.target.value}

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doggyfi-official/kobosu",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": false,
   "description": "A MetaMask snap for managing Dogecoin meta assets",
   "license": "Apache-2.0",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A snap to manage Dogecoin and Doginals meta assets",
   "proposedName": "kobosu",
   "source": {
-    "shasum": "Fam6/TAsw/79zED4qHzH0mZxjqcmr7qVaDZG7bytlEE=",
+    "shasum": "XSHO5B2+kgh1E0/9Nh2ZtjfwkIhhdUWfcCW00FYCatc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/doginals/dunesMethods/extractDuneUtxo.ts
+++ b/packages/snap/src/doginals/dunesMethods/extractDuneUtxo.ts
@@ -6,10 +6,10 @@ import { bigIntToDecimalString, decimalToBigInt } from './bigIntMethods';
 /**
  * Function to extract a specific dune utxo from the wallet.
  *
- * @param wallet
- * @param amount
- * @param dune
- * @returns
+ * @param wallet - Apezord compatable wallet.
+ * @param amount - The amount to extract.
+ * @param dune - The dune to extract.
+ * @returns The utxo and dune info.
  */
 export async function extractDuneUtxo(
   wallet: Wallet,
@@ -23,15 +23,9 @@ export async function extractDuneUtxo(
   }
   const duneID = resp.id;
   const decimals = resp.divisibility;
-  let duneUtxos: APEUTXO[] = [];
+  const duneUtxos: APEUTXO[] = [];
   for (const utxo of wallet.utxos) {
-    if (utxo.dunes.length > 0 &&
-      utxo.dunes[0].dune_id === duneID) {
-      }
-    if (
-      utxo.dunes.length > 0 &&
-      utxo.dunes[0].dune_id === duneID
-    ) {
+    if (utxo.dunes.length > 0 && utxo.dunes[0].dune_id === duneID) {
       const stringDec = bigIntToDecimalString(amount, decimals);
       if (utxo.dunes[0].amount === stringDec) {
         duneUtxos.push(utxo);
@@ -46,6 +40,7 @@ export async function extractDuneUtxo(
  * Sums the decimal parts of the input amounts and returns a string with the correct decimal placement.
  *
  * @param amounts - An array of decimal strings.
+ * @param decimals - The number of decimals.
  * @returns A string with the correct decimal placement.
  */
 function sumDecimalStrings(amounts: string[], decimals: number): string {
@@ -57,8 +52,7 @@ function sumDecimalStrings(amounts: string[], decimals: number): string {
       throw new Error('Amounts must not include scientific notation!');
     }
     const [integerPart, fractionalPart = ''] = amount.split('.');
-    const normalizedAmount =
-      integerPart + fractionalPart.padEnd(decimals, '0');
+    const normalizedAmount = integerPart + fractionalPart.padEnd(decimals, '0');
     totalAmount += BigInt(normalizedAmount);
   }
 
@@ -73,20 +67,20 @@ function sumDecimalStrings(amounts: string[], decimals: number): string {
     : `0.${'0'.repeat(-integerPartLength)}${totalString}`;
 }
 
-
 /**
- * Gets the Dune UTXOs that can at least cover the the total amount to send
+ * Gets the Dune UTXOs that can at least cover the the total amount to send.
  *
- * @param wallet -- Apezord Wallet object.
- * @param amounts -- Human interpretable amounts based on divisibility.
- * @param dune Name of the dune.
+ * @param wallet - Apezord Wallet object.
+ * @param amounts - Human interpretable amounts based on divisibility.
+ * @param dune - Name of the dune.
+ * @param checkForSingleUtxo - Whether to check for a single utxo.
  * @returns A promise that resolves to an object containing the specific dune utxos, the dune info, and the total amount.
  */
 export async function extractDuneUtxos(
   wallet: Wallet,
   amounts: string[],
   dune: string,
-  checkForSingleUtxo: boolean = false,
+  checkForSingleUtxo = false,
 ): Promise<{
   duneUtxos: APEUTXO[];
   duneInfo: DuneInfo;
@@ -98,43 +92,77 @@ export async function extractDuneUtxos(
     throw new Error('Could not fetch dune info');
   }
   const totalAmount = sumDecimalStrings(amounts, resp.divisibility);
+  const totalAmountBigInt = decimalToBigInt(totalAmount, resp.divisibility);
 
   if (checkForSingleUtxo) {
     const _ = await extractDuneUtxo(wallet, totalAmount.toString(), dune);
 
-    if (_ !== null && _.utxo) {
-      return {
-        duneUtxos: [_.utxo],
-        duneInfo: _.info,
-        totalAmount: totalAmount.toString(),
-      };
+    if (_ !== null) {
+      if (_.utxo) {
+        return {
+          duneUtxos: [_.utxo],
+          duneInfo: _.info,
+          totalAmount: totalAmount.toString(),
+        };
+      }
     }
   }
   // get id for the dune
   const duneID = resp.id;
 
-  let duneUtxos: APEUTXO[] = [];
-  let amountAcc = BigInt(0);
-
+  // first, let's isolate only the utxos that match the dune
+  const _duneUtxos: APEUTXO[] = [];
   for (const utxo of wallet.utxos) {
-    if (utxo && 'dunes' in utxo && utxo.dunes && utxo.dunes.length > 0 && utxo.dunes[0].dune_id === duneID) {
-      const duneBalance = utxo.dunes[0];
-      if (amountAcc >= totalAmount) {
-        break;
-      }
-      const _ = await extractDuneUtxo(
-        wallet,
-        duneBalance.amount.toString(),
-        dune,
-      );
-      if (_ !== null) {
-        duneUtxos.push(utxo);
-        amountAcc += decimalToBigInt(utxo.dunes[0].amount, Number(_.info.divisibility));
-      }
+    if (
+      utxo &&
+      'dunes' in utxo &&
+      utxo.dunes &&
+      utxo.dunes.length > 0 &&
+      utxo.dunes[0].dune_id === duneID
+    ) {
+      _duneUtxos.push(utxo);
     }
   }
-  if (duneUtxos.length === 0) {
+
+  // next, let's sort the utxos by the dune amount
+  // parseFloat should be fine here as it returns a number which is bigger than dunes cap.
+  _duneUtxos.sort((a, b) => {
+    return parseFloat(b.dunes[0].amount) - parseFloat(a.dunes[0].amount);
+  });
+
+  // now, let's add the utxos to the final list
+  let amountAcc = BigInt(0);
+  const finalDuneUtxos: APEUTXO[] = [];
+
+  for (const utxo of _duneUtxos) {
+    const duneBalance = utxo.dunes[0];
+    if (amountAcc >= totalAmountBigInt) {
+      break;
+    }
+    const _ = await extractDuneUtxo(
+      wallet,
+      duneBalance.amount.toString(),
+      dune,
+    );
+    if (_ !== null) {
+      finalDuneUtxos.push(utxo);
+      amountAcc += decimalToBigInt(
+        utxo.dunes[0].amount,
+        Number(_.info.divisibility),
+      );
+    }
+  }
+
+  if (finalDuneUtxos.length === 0) {
     return null;
   }
-  return { duneUtxos: duneUtxos, duneInfo: resp, totalAmount: bigIntToDecimalString(amountAcc.toString(), Number(resp.divisibility)) };
+
+  return {
+    duneUtxos: finalDuneUtxos,
+    duneInfo: resp,
+    totalAmount: bigIntToDecimalString(
+      amountAcc.toString(),
+      Number(resp.divisibility),
+    ),
+  };
 }


### PR DESCRIPTION
Fixes bug with amountAcc > totalAmount compairing Bigint to string on extractDunesUtxos AND optimizes extractDunesUtxos to sort the dunes from largest to smallest. This will lead to much lower network fees for users with many small dunes of the same id.